### PR TITLE
embulk supports integer as :integer

### DIFF
--- a/lib/embulk/input_redis.rb
+++ b/lib/embulk/input_redis.rb
@@ -9,12 +9,12 @@ module Embulk
     def self.transaction(config, &control)
       task = {
         'host' => config.param('host', :string, :default => 'localhost'),
-        'port' => config.param('port', :int, :default => 6379),
-        'db' => config.param('db', :int, :default => 0),
+        'port' => config.param('port', :integer, :default => 6379),
+        'db' => config.param('db', :integer, :default => 0),
         'key_prefix' => config.param('key_prefix', :string, :default => ''),
         'encode' => config.param('encode', :string, :default => 'json'),
       }
-      threads = config.param('threads', :int, default: 1)
+      threads = config.param('threads', :integer, default: 1)
 
       columns = [
         Column.new(0, 'key', :string),

--- a/lib/embulk/output_redis.rb
+++ b/lib/embulk/output_redis.rb
@@ -9,8 +9,8 @@ module Embulk
     def self.transaction(config, schema, processor_count, &control)
       task = {
         'host' => config.param('host', :string, :default => 'localhost'),
-        'port' => config.param('port', :int, :default => 6379),
-        'db' => config.param('db', :int, :default => 0),
+        'port' => config.param('port', :integer, :default => 6379),
+        'db' => config.param('db', :integer, :default => 0),
         'key' => config.param('key', :string),
         'key_prefix' => config.param('key_prefix', :string, :default => ''),
         'encode' => config.param('encode', :string, :default => 'json'),
@@ -41,7 +41,7 @@ module Embulk
             v = hash.to_json
             @redis.set("#{task['key_prefix']}#{hash[task['key']]}", v)
           end
-        @records += 1 
+        @records += 1
       end
     end
 


### PR DESCRIPTION
Hi
I tried to use this plugin with

```
$ java -jar embulk-0.2.0.jar example ./try1
$ java -jar embulk-0.2.0.jar guess ./try1/example.yml -o config.yml
/* modify config.yml to use redis-plugin */
$ java -jar embulk-0.2.0.jar run ./try1/example.yml -o config.yml
```

and I met error

```
2015-01-28 00:13:14,449 [INFO]: main:org.embulk.standards.LocalFileInputPlugin: Listing local files with prefix '/home/kumagi/develop/embulk/try2/csv'
ArgumentError: Unknown type "int"
        param at /home/kumagi/develop/embulk/lib/embulk/data_source.rb:26
  transaction at /home/kumagi/.embulk/jruby/1.9/gems/embulk-plugin-redis-0.1.1/lib/embulk/output_redis.rb:10
  transaction at /home/kumagi/develop/embulk/lib/embulk/output_plugin.rb:53
  transaction at Embulk$$OutputPlugin$$JavaAdapter_979258935.gen:13
          run at file:/home/kumagi/develop/embulk/embulk-0.2.0.jar!/embulk/command/embulk_run.rb:195
       (root) at classpath:embulk/command/embulk.rb:39
```

It seems to be using wrong `ruby_type`. 
embulk supports types `:integer, :float, :string, :bool, :hash, :array`

https://github.com/embulk/embulk/blob/master/lib/embulk/data_source.rb#L10

How about replace `:int` with `:integer`?
