### PR TITLE
add depedency of redis client library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "http://rubygems.org"
 gemspec
+
+gem 'redis'


### PR DESCRIPTION
Sorry for trivial.
This library uses `redis` client library, but this library is not specified in `Gemfile`.
Isn't it necessary?
